### PR TITLE
remove relative import

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -2,16 +2,15 @@
 // Use of this source code is governed by an MIT-style license
 // that can be found in the LICENSE file.
 
-package consistent_test
+package consistent
 
 import (
-	"../consistent"
 	"fmt"
 	"log"
 )
 
 func ExampleNew() {
-	c := consistent.New()
+	c := New()
 	c.Add("cacheA")
 	c.Add("cacheB")
 	c.Add("cacheC")
@@ -32,7 +31,7 @@ func ExampleNew() {
 }
 
 func ExampleAdd() {
-	c := consistent.New()
+	c := New()
 	c.Add("cacheA")
 	c.Add("cacheB")
 	c.Add("cacheC")
@@ -72,7 +71,7 @@ func ExampleAdd() {
 }
 
 func ExampleRemove() {
-	c := consistent.New()
+	c := New()
 	c.Add("cacheA")
 	c.Add("cacheB")
 	c.Add("cacheC")


### PR DESCRIPTION
解决此问题，以确保 roc 在 Go 1.18 下 build 通过。